### PR TITLE
Fix for the incorrect id being passed through on the drop event.

### DIFF
--- a/addon/components/karbon-sortable-list.js
+++ b/addon/components/karbon-sortable-list.js
@@ -298,7 +298,6 @@ export default Ember.Component.extend({
     // --- dragstart ---
     this.$().on('dragstart.karbonsortable', (event) => {
 
-      event.dataTransfer.setData("text/plain", event.target.id);
       event.dataTransfer.effectAllowed = 'move';
       event.dataTransfer.dropEffect = 'move';
 


### PR DESCRIPTION
The element id was being set instead of the data id. Allows the karbon-sortable-item to set the data id via the ondragstart event.