### PR TITLE
Feature/support for dragging between lists

### DIFF
--- a/addon/components/karbon-dropwell.js
+++ b/addon/components/karbon-dropwell.js
@@ -40,8 +40,10 @@ export default Ember.Component.extend({
       if (!this.get('disable')) {
         this.set('dragover', false);
 
-        const dropWellId = this.get('data');
-        const droppedItemId = event.dataTransfer.getData('text');
+        const stringData = event.dataTransfer && event.dataTransfer.getData('dragData');
+        if(!stringData || !stringData.length) return;
+        const data = JSON.parse(stringData);
+        const droppedItemId = data && data.pkid;
 
         this.get('onDropOnWell')(dropWellId, droppedItemId);
       }

--- a/addon/components/karbon-sortable-item.js
+++ b/addon/components/karbon-sortable-item.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
   tagName: 'li',
   classNames: ['spacer'],
   classNameBindings: ['handleClass', 'isSection:section', 'isNested:nested'],
-  attributeBindings: ['draggable', 'pkid:data-pkid'],
+  attributeBindings: ['draggable', 'pkid:data-pkid', 'type:data-type'],
   handleClass: 'droppable',
 
   draggable: true,
@@ -15,7 +15,16 @@ export default Ember.Component.extend({
   layout,
 
   didInsertElement() {
-    // Dropwells grab the id from here on a drop
-    this.$().attr('ondragstart', "event.dataTransfer.setData('text/plain', '" + this.get('pkid') +  "')");
+    // Dropwells grab the id from here on a drop. The data is also passed via the `externalItemDropped` event on a karbon-sortable-list.
+    const self = this;
+    this.$().on("dragstart", function (e) {
+      //If we are dragging a child lists item it will fire first and we want to make sure we dont override it with the parent list item data.
+      if(e.originalEvent.dataTransfer.getData("dragData").length) return;
+
+      const data = {pkid: self.get('pkid'), type: self.get('type')};
+      var j = JSON.stringify(data);
+      e.originalEvent.dataTransfer.setData("dragData", j);
+    });
+
   }
 });

--- a/addon/components/karbon-sortable-list.js
+++ b/addon/components/karbon-sortable-list.js
@@ -272,7 +272,8 @@ export default Ember.Component.extend({
   _clearDragData() {
     this.setProperties({
       '_draggedEl': null,
-      '_draggedItem': null
+      '_draggedItem': null,
+      '_screenX': null
     });
   },
 
@@ -421,21 +422,21 @@ export default Ember.Component.extend({
         if (this.get('nestingAllowed')) {
           // indent/outdent
           const screenX = this.get('_screenX');
-          const newScreenX = event.originalEvent.screenX;
+          const newScreenX = event.screenX;
 
           const nest = draggedEl.hasClass('nesting') || draggedEl.hasClass('nested');
 
-          if (!screenX) {
+          if (!screenX || (Math.abs(newScreenX - screenX) > 100)) {
             this.set('_screenX', newScreenX);
           } else {
             const deltaX = newScreenX - screenX;
             const nestTolerance = this.get('nestTolerance');
 
-            if (deltaX < (-1 * nestTolerance) && nest) {
+            if (nest && (deltaX < (-1 * nestTolerance))) {
               // outdent
               this._applyClasses(draggedEl, ['nesting', 'nested'], null);
               this.set('_screenX', newScreenX);
-            } else if (deltaX > nestTolerance && !nest) {
+            } else if (!nest && (deltaX > nestTolerance)) {
               // indent
               this._applyClasses(draggedEl, null, ['nesting']);
               this.set('_screenX', newScreenX);

--- a/addon/components/karbon-sortable-list.js
+++ b/addon/components/karbon-sortable-list.js
@@ -275,6 +275,9 @@ export default Ember.Component.extend({
       '_draggedItem': null,
       '_screenX': null
     });
+
+    const dsi = document.getElementById('dragSingleImage');
+    if (dsi) dsi.remove();
   },
 
   _hasDragData() {
@@ -328,12 +331,33 @@ export default Ember.Component.extend({
         this.set('_screenX', null);
       }
 
-      try {
-        const dragImageEl = document.getElementById('dragSingleImage');
-        const width = Ember.$(dragImageEl).width();
-        const height = Ember.$(dragImageEl).height();
 
-        event.dataTransfer.setDragImage(dragImageEl, Math.floor(width/2), Math.floor(height/2));
+      try {
+        // Chrome (and others?) changed the way they use dragSingleImage. Now
+        // we need to build the DOM record and insert it just before we set it,
+        // then remove it on drag end. Unfortunately it means we have to pull
+        // the classes in here.
+
+        const dragImageEl = document.createElement('div');
+        dragImageEl.setAttribute('id', 'dragSingleImage');
+
+        const thumbnail = document.createElement('div');
+        thumbnail.setAttribute('class', 'checklist__thumbnail');
+
+        const circle = document.createElement('div');
+        circle.setAttribute('class', 'checklist__thumbnail--circle');
+
+        const rectangle = document.createElement('div');
+        rectangle.setAttribute('class', 'checklist__thumbnail--rectangle');
+
+        thumbnail.appendChild(circle);
+        thumbnail.appendChild(rectangle);
+
+        dragImageEl.appendChild(thumbnail);
+
+        document.body.appendChild(dragImageEl);
+
+        event.dataTransfer.setDragImage(dragImageEl, Math.floor(105/2), Math.floor(23/2));
       } catch (e) {
         // ie doesn't like setDragImage
       }

--- a/addon/components/karbon-sortable-list.js
+++ b/addon/components/karbon-sortable-list.js
@@ -217,6 +217,15 @@ export default Ember.Component.extend({
     }
   },
 
+  _isDroppingDownwards: function (droppable, event) {
+    //Checks the 50 / 50 rule and adjust the drop index.
+    const next = Ember.$(droppable).next();
+    const midPoint = droppable.offset().top + droppable.height() / 2;
+    //As the event firing could be a nested child, we use the client offset.
+    const dragPoint = event.pageY;
+    return (dragPoint > midPoint);
+  },
+
   nestingAllowed: Ember.computed('canNest', '_nestingEnabled', function() {
     return this.get('canNest') && this.get('_nestingEnabled');
   }),
@@ -687,7 +696,9 @@ export default Ember.Component.extend({
         // clear the borders
         this._applyClasses(droppable, ['droppable--above', 'droppable--below'], ['spacer']);
         //Fire the drop event
-        this.get('externalItemDropped') && this.get('externalItemDropped')(droppedItemData, droppable && Ember.$(droppable).index(), event);
+        let newDropIndex = Ember.$(droppable).index();
+        if(this._isDroppingDownwards(droppable, event)) newDropIndex++;
+        if(droppable) this.get('externalItemDropped') && this.get('externalItemDropped')(droppedItemData, newDropIndex, event);
       } else if (externalItem) {
         this.set('invalidDragOver', true);
         return;

--- a/addon/components/karbon-sortable-list.js
+++ b/addon/components/karbon-sortable-list.js
@@ -696,9 +696,11 @@ export default Ember.Component.extend({
         // clear the borders
         this._applyClasses(droppable, ['droppable--above', 'droppable--below'], ['spacer']);
         //Fire the drop event
-        let newDropIndex = Ember.$(droppable).index();
-        if(this._isDroppingDownwards(droppable, event)) newDropIndex++;
-        if(droppable) this.get('externalItemDropped') && this.get('externalItemDropped')(droppedItemData, newDropIndex, event);
+        let dropIndex = Ember.$(droppable).index();
+        //Sometimes we want to know the index dropped on, other times the new location index.
+        let newIndex = dropIndex;
+        if(this._isDroppingDownwards(droppable, event)) newIndex++;
+        if(droppable) this.get('externalItemDropped') && this.get('externalItemDropped')(droppedItemData, dropIndex, newIndex, event);
       } else if (externalItem) {
         this.set('invalidDragOver', true);
         return;

--- a/addon/components/karbon-sortable-list.js
+++ b/addon/components/karbon-sortable-list.js
@@ -245,7 +245,7 @@ export default Ember.Component.extend({
       this.set('_dragGroup', null);
       this.set('_nestingEnabled', true);
     } else {
-      let children = this._getChildren(el);
+      let children = this._getChildren(el) || [];
 
       // We are dragging a group, so normal nesting rules do not apply
       this.set('_nestingEnabled', false);


### PR DESCRIPTION
Adds support to allow dragging items between lists. If the item dropped does not belong to the current list an event is triggered to allow the parent component to manage the moving of the dropped list item.